### PR TITLE
fix: add JSDoc annotations '@private' (#70)

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,24 +5,11 @@
 <dd></dd>
 </dl>
 
-## Members
-
-<dl>
-<dt><a href="#validate">validate</a> ⇒ <code>Array.&lt;Object&gt;</code></dt>
-<dd></dd>
-</dl>
-
 ## Functions
 
 <dl>
 <dt><a href="#bundle">bundle(files, [options])</a> ⇒ <code><a href="#Document">Document</a></code></dt>
 <dd></dd>
-<dt><a href="#isExternalReference">isExternalReference(ref)</a> ⇒ <code>boolean</code></dt>
-<dd><p>Checks if <code>ref</code> is an external reference.</p></dd>
-<dt><a href="#resolveExternalRefs">resolveExternalRefs(parsedJSON, $refs)</a> ⇒ <code>ExternalComponents</code></dt>
-<dd></dd>
-<dt><a href="#parse">parse(JSONSchema)</a></dt>
-<dd><p>Resolves external references and updates $refs.</p></dd>
 </dl>
 
 <a name="Document"></a>
@@ -65,17 +52,6 @@ console.log(document.string()); // get JSON string
 
 ### document.string() ⇒ <code>string</code>
 **Kind**: instance method of [<code>Document</code>](#Document)  
-<a name="validate"></a>
-
-## validate ⇒ <code>Array.&lt;Object&gt;</code>
-**Kind**: global variable  
-
-| Param | Type |
-| --- | --- |
-| asyncapiDocuments | <code>Object</code> | 
-| options | <code>Object</code> | 
-| options.referenceIntoComponents | <code>boolean</code> | 
-
 <a name="bundle"></a>
 
 ## bundle(files, [options]) ⇒ [<code>Document</code>](#Document)
@@ -104,41 +80,3 @@ async function main() {
 
 main().catch(e => console.error(e));
 ```
-<a name="bundle..resolvedJsons"></a>
-
-### bundle~resolvedJsons
-<p>Bundle all external references for each file.</p>
-
-**Kind**: inner constant of [<code>bundle</code>](#bundle)  
-<a name="isExternalReference"></a>
-
-## isExternalReference(ref) ⇒ <code>boolean</code>
-<p>Checks if <code>ref</code> is an external reference.</p>
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| ref | <code>string</code> | 
-
-<a name="resolveExternalRefs"></a>
-
-## resolveExternalRefs(parsedJSON, $refs) ⇒ <code>ExternalComponents</code>
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| parsedJSON | <code>Array.&lt;Object&gt;</code> | 
-| $refs | <code>$RefParser</code> | 
-
-<a name="parse"></a>
-
-## parse(JSONSchema)
-<p>Resolves external references and updates $refs.</p>
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| JSONSchema | <code>Array.&lt;Object&gt;</code> | 
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export default async function bundle(files: string[], options: any = {}) {
 
   /**
    * Bundle all external references for each file.
+   * @private
    */
   const resolvedJsons = await resolve(parsedJsons, {
     referenceIntoComponents: options.referenceIntoComponents,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,6 +5,10 @@ import { merge } from 'lodash';
 import type { $Refs } from '@apidevtools/json-schema-ref-parser';
 import type { AsyncAPIObject, ComponentsObject, MessageObject } from './spec-types';
 
+/**
+ * @class
+ * @private
+ */
 class ExternalComponents {
   ref;
   resolvedJSON;
@@ -23,6 +27,9 @@ class ExternalComponents {
   }
 }
 
+/**
+ * @private
+ */
 function crawlChannelPropertiesForRefs(JSONSchema: AsyncAPIObject) {
   // eslint-disable-next-line
   return JSONPath({ json: JSONSchema, path: `$.channels.*.*.message['$ref']` });
@@ -32,6 +39,7 @@ function crawlChannelPropertiesForRefs(JSONSchema: AsyncAPIObject) {
  * Checks if `ref` is an external reference.
  * @param {string} ref
  * @returns {boolean}
+ * @private
  */
 function isExternalReference(ref: string) {
   return !ref.startsWith('#');
@@ -42,6 +50,7 @@ function isExternalReference(ref: string) {
  * @param {Object[]} parsedJSON
  * @param {$RefParser} $refs
  * @returns {ExternalComponents}
+ * @private
  */
 async function resolveExternalRefs(parsedJSON: AsyncAPIObject, $refs: $Refs) {
   const componentObj: ComponentsObject = { messages: {} };
@@ -71,6 +80,7 @@ async function resolveExternalRefs(parsedJSON: AsyncAPIObject, $refs: $Refs) {
 /**
  * Resolves external references and updates $refs.
  * @param {Object[]} JSONSchema
+ * @private
  */
 export async function parse(JSONSchema: AsyncAPIObject) {
   const $ref: any = await $RefParser.resolve(JSONSchema);

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,6 +6,9 @@ import { ParserError } from './errors';
 
 import type { AsyncAPIObject } from './spec-types';
 
+/**
+ * @private
+ */
 export const toJS = (asyncapiYAMLorJSON: string | object) => {
   if (!asyncapiYAMLorJSON) {
     throw new ParserError({
@@ -38,6 +41,9 @@ export const toJS = (asyncapiYAMLorJSON: string | object) => {
   return yaml.load(asyncapiYAMLorJSON);
 };
 
+/**
+ * @private
+ */
 export const validate = async (
   parsedJSONs: AsyncAPIObject[],
   parser: { parse(asyncapi: string | any): Promise<any> }
@@ -53,6 +59,7 @@ export const validate = async (
  * @param {Object} options
  * @param {boolean} options.referenceIntoComponents
  * @returns {Array<Object>}
+ * @private
  */
 export const resolve = async (
   asyncapiDocuments: AsyncAPIObject[],


### PR DESCRIPTION
This PR adds JSDoc annotations `@private` to classes and functions for versioning reasons.

Fixes https://github.com/asyncapi/bundler/issues/70