### PR TITLE
fix: fix generation of NPM release package (#75, #78)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "lint:fix": "eslint --max-warnings 0 --config .eslintrc . --fix",
     "generate:assets": "npm run build && npm run docs && npm run generate:readme:toc",
-    "generate:readme:toc": "markdown-toc -i README.md"
+    "generate:readme:toc": "markdown-toc -i README.md",
+    "prepublishOnly": "npm run generate:assets"
   },
   "repository": {
     "type": "git",
@@ -32,6 +33,7 @@
     "access": "public"
   },
   "files": [
+    "API.md",
     "LICENSE",
     "README.md",
     "/lib"


### PR DESCRIPTION
This PR adds building of the TypeScript code (transpilation to JavaScript) during release process, which was not required before migration of the codebase to TS, and therefore did not exist.
Due to absence of this step, after migration to TS NPM package was released without `lib` directory, which made the package unusable for end users.

Besides adding the building step, this PR also modifies `files` array of the `package.json` to include in the package file `API.md`.


Fixes https://github.com/asyncapi/bundler/issues/75
Fixes https://github.com/asyncapi/bundler/issues/78