### PR TITLE
chore: add aeworxet as a codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @Souvikns @derberg @asyncapi-bot-eve
+* @Souvikns @derberg @aeworxet @asyncapi-bot-eve


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

I think now we should add @aeworxet as a code owner to this project, @derberg I don't think we need tsc confirmation for this right? 

