### PR TITLE
fix: add check that `$ref` value is a `string` (#92)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,8 +41,8 @@ function crawlChannelPropertiesForRefs(JSONSchema: AsyncAPIObject) {
  * @returns {boolean}
  * @private
  */
-function isExternalReference(ref: string) {
-  return !ref.startsWith('#');
+function isExternalReference(ref: string): boolean {
+  return typeof ref === 'string' && !ref.startsWith('#');
 }
 
 /**

--- a/tests/lib/index.spec.ts
+++ b/tests/lib/index.spec.ts
@@ -44,6 +44,9 @@ describe('bundler should ', () => {
   test('should not throw if value of `$ref` is not a string', async () => {
     const files = ['./tests/wrong-ref-not-string.yaml'];
 
+    // If async function `bundle()` resolved Promise successfully, that means it
+    // did not throw exception during process of execution, which is the
+    // objective of testing.
     expect(
       await bundle(
         files.map(file =>
@@ -59,6 +62,9 @@ describe('bundler should ', () => {
   test('should not throw if value of `$ref` is absent', async () => {
     const files = ['./tests/wrong-ref-absent.yaml'];
 
+    // If async function `bundle()` resolved Promise successfully, that means it
+    // did not throw exception during process of execution, which is the
+    // objective of testing.
     expect(
       await bundle(
         files.map(file =>

--- a/tests/lib/index.spec.ts
+++ b/tests/lib/index.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, jest } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import bundle from '../../src';
 import fs from 'fs';
 import path from 'path';

--- a/tests/lib/index.spec.ts
+++ b/tests/lib/index.spec.ts
@@ -40,4 +40,36 @@ describe('bundler should ', () => {
 
     expect(message.$ref).toMatch('#/components/messages/UserSignedUp');
   });
+
+  test('should not throw if value of `$ref` is not a string', async () => {
+    const files = ['./tests/wrong-ref-not-string.yaml'];
+    const response = await bundle(
+      files.map(file =>
+        fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8')
+      ),
+      {
+        referenceIntoComponents: true,
+      }
+    );
+
+    const result = response.json();
+
+    expect(result).toBeDefined();
+  });
+
+  test('should not throw if value of `$ref` is absent', async () => {
+    const files = ['./tests/wrong-ref-absent.yaml'];
+    const response = await bundle(
+      files.map(file =>
+        fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8')
+      ),
+      {
+        referenceIntoComponents: true,
+      }
+    );
+
+    const result = response.json();
+
+    expect(result).toBeDefined();
+  });
 });

--- a/tests/lib/index.spec.ts
+++ b/tests/lib/index.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test, jest } from '@jest/globals';
 import bundle from '../../src';
 import fs from 'fs';
 import path from 'path';
@@ -43,33 +43,31 @@ describe('bundler should ', () => {
 
   test('should not throw if value of `$ref` is not a string', async () => {
     const files = ['./tests/wrong-ref-not-string.yaml'];
-    const response = await bundle(
-      files.map(file =>
-        fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8')
-      ),
-      {
-        referenceIntoComponents: true,
-      }
-    );
 
-    const result = response.json();
-
-    expect(result).toBeDefined();
+    expect(
+      await bundle(
+        files.map(file =>
+          fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8')
+        ),
+        {
+          referenceIntoComponents: true,
+        }
+      )
+    ).resolves;
   });
 
   test('should not throw if value of `$ref` is absent', async () => {
     const files = ['./tests/wrong-ref-absent.yaml'];
-    const response = await bundle(
-      files.map(file =>
-        fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8')
-      ),
-      {
-        referenceIntoComponents: true,
-      }
-    );
 
-    const result = response.json();
-
-    expect(result).toBeDefined();
+    expect(
+      await bundle(
+        files.map(file =>
+          fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8')
+        ),
+        {
+          referenceIntoComponents: true,
+        }
+      )
+    ).resolves;
   });
 });

--- a/tests/wrong-ref-absent.yaml
+++ b/tests/wrong-ref-absent.yaml
@@ -1,0 +1,10 @@
+asyncapi: '2.2.0'
+info:
+  title: Account Service
+  version: 1.0.0
+  description: This service is in charge of processing user signups
+channels:
+  user/signedup:
+    subscribe:
+      message:
+        $ref:

--- a/tests/wrong-ref-not-string.yaml
+++ b/tests/wrong-ref-not-string.yaml
@@ -1,0 +1,10 @@
+asyncapi: '2.2.0'
+info:
+  title: Account Service
+  version: 1.0.0
+  description: This service is in charge of processing user signups
+channels:
+  user/signedup:
+    subscribe:
+      message:
+        $ref: 5


### PR DESCRIPTION
This PR adds to function `isExternalReference()` additional check if `$ref`'s value passed to it has the type of `string` (adds type guard for JS version, to which TS code will be transpiled when NPM package is released).

Except general usefulness, it is also a possible indirect fix of an issue reported by user in
https://asyncapi.slack.com/archives/CQVJXFNQL/p1666700935030749
(excerpt from the conversation is mirrored in repository's issue https://github.com/asyncapi/bundler/issues/92).