### PR TITLE
test: add unit testing

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,7 +41,7 @@ function crawlChannelPropertiesForRefs(JSONSchema: AsyncAPIObject) {
  * @returns {boolean}
  * @private
  */
-function isExternalReference(ref: string): boolean {
+export function isExternalReference(ref: string): boolean {
   return typeof ref === 'string' && !ref.startsWith('#');
 }
 

--- a/tests/lib/index.spec.ts
+++ b/tests/lib/index.spec.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from '@jest/globals';
 import bundle from '../../src';
+import { isExternalReference } from '../../src/parser';
 import fs from 'fs';
 import path from 'path';
 
 import type { ReferenceObject } from '../../src/spec-types';
 
-describe('bundler should ', () => {
+describe('[integration testing] bundler should ', () => {
   test('should return bundled doc', async () => {
     const files = ['./tests/camera.yml', './tests/audio.yml'];
     const response = await bundle(
@@ -75,5 +76,14 @@ describe('bundler should ', () => {
         }
       )
     ).resolves;
+  });
+});
+
+describe('[unit testing]', () => {
+  test('`isExternalReference()` should return `true` on external reference', () => {
+    expect(isExternalReference('./components/messages/UserSignedUp')).toBeTruthy();
+  });
+  test('`isExternalReference()` should return `false` on local reference', () => {
+    expect(isExternalReference('#/components/messages/UserSignedUp')).toBeFalsy();
   });
 });


### PR DESCRIPTION
This PR adds unit testing as a separate Jest test suite.

Jest's `.not.toThrow()` assertion was not added because TypeScript will not allow anything other than `string` to be passed to a function whose parameter is defined as having the type of `string`, anyway. The type guard `typeof ref === 'string'` exists for the loosely typed JavaScript only.

![image](https://user-images.githubusercontent.com/16149591/201877562-7d3d8375-7838-481a-b6c9-c94c63dc5881.png)
