### PR TITLE
test: modify location of `ts-jest` config in `jest.config.js`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,12 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json',
+      },
+    ],
   },
 
   // Test spec file resolution pattern
@@ -24,9 +29,4 @@ module.exports = {
   testTimeout: 20000,
   
   //setupFiles: ['./tests/jest.setup.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.test.json',
-    },
-  },
 };


### PR DESCRIPTION
This PR modifies location of `ts-jest` config in `jest.config.js` file to address warning
```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```

PR with changes to `ts-jest` configuration:
https://github.com/kulshekhar/ts-jest/pull/3780
