### PR TITLE
fix: fix typos in `RegExp`s of JSON Pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,11 @@ There are no internal references that MUST be `Reference Object`s.
 Regexes of internal references that MUST be `Reference Object`s:
 
 ```
-/#\/channels\/,*\/servers/
+/#\/channels\/.*\/servers/
 /#\/operations\/.*\/channel/
 /#\/operations\/.*\/messages/
 /#\/operations\/.*\/reply\/channel/
-/#\/operations\/,*\/reply\/messages/
+/#\/operations\/.*\/reply\/messages/
 /#\/components\/channels\/.*\/servers/
 /#\/components\/operations\/.*\/channel/
 /#\/components\/operations\/.*\/messages/

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -48,11 +48,11 @@ export async function parse(
           excludedPathMatcher: (path: string): any => {
             return (
               // prettier-ignore
-              (/#\/channels\/,*\/servers/).test(path) ||
+              (/#\/channels\/.*\/servers/).test(path) ||
               (/#\/operations\/.*\/channel/).test(path) ||
               (/#\/operations\/.*\/messages/).test(path) ||
               (/#\/operations\/.*\/reply\/channel/).test(path) ||
-              (/#\/operations\/,*\/reply\/messages/).test(path) ||
+              (/#\/operations\/.*\/reply\/messages/).test(path) ||
               (/#\/components\/channels\/.*\/servers/).test(path) ||
               (/#\/components\/operations\/.*\/channel/).test(path) ||
               (/#\/components\/operations\/.*\/messages/).test(path) ||


### PR DESCRIPTION
This PR fixes typos in `RegExp`s of JSON Pointers.