### PR TITLE
fix: chdir back to the starting directory before exit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,9 @@ export default async function bundle(
   }
 
   if (options.baseDir && typeof options.baseDir === 'string') {
-    process.chdir(path.resolve(originDir, options.baseDir));
+    process.chdir(options.baseDir);
   } else if (options.baseDir && Array.isArray(options.baseDir)) {
-    process.chdir(path.resolve(originDir, String(options.baseDir[0]))); // guard against passing an array
+    process.chdir(String(options.baseDir[0])); // guard against passing an array
   }
 
   const readFiles = files.map(file => readFileSync(file, 'utf-8')); // eslint-disable-line

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'fs';
-import path from 'path';
 import { toJS, resolve, versionCheck } from './util';
 import { Document } from './document';
 import { parse } from './parser';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import { parse } from './parser';
 
 import type { AsyncAPIObject } from './spec-types';
 
+// remember the directory where execution of the program started
+const originDir = String(process.cwd());
+
 /**
  *
  * @param {string | string[]} files One or more relative/absolute paths to
@@ -81,9 +84,6 @@ export default async function bundle(
   files: string[] | string,
   options: any = {}
 ) {
-  // remember the directory where execution of the program started
-  const originDir = String(process.env.PWD);
-
   // if one string was passed, convert it to an array
   if (typeof files === 'string') {
     files = Array.from(files.split(' '));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
 import { readFileSync } from 'fs';
+import path from 'path';
 import { toJS, resolve, versionCheck } from './util';
 import { Document } from './document';
 import { parse } from './parser';
 
 import type { AsyncAPIObject } from './spec-types';
+
+// remember the directory where execution of the program started
+export const originDir: string = String(process.env.PWD);
 
 /**
  *
@@ -87,9 +91,9 @@ export default async function bundle(
   }
 
   if (options.baseDir && typeof options.baseDir === 'string') {
-    process.chdir(options.baseDir);
+    process.chdir(path.resolve(originDir, options.baseDir));
   } else if (options.baseDir && Array.isArray(options.baseDir)) {
-    process.chdir(String(options.baseDir[0])); // guard against passing an array
+    process.chdir(path.resolve(originDir, String(options.baseDir[0]))); // guard against passing an array
   }
 
   const readFiles = files.map(file => readFileSync(file, 'utf-8')); // eslint-disable-line
@@ -113,6 +117,9 @@ export default async function bundle(
     majorVersion,
     options
   );
+
+  // return to the starting directory before finishing the execution
+  process.chdir(originDir);
 
   return new Document(resolvedJsons, options.base);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { parse } from './parser';
 import type { AsyncAPIObject } from './spec-types';
 
 // remember the directory where execution of the program started
-export const originDir: string = String(process.env.PWD);
+export const originDir = String(process.env.PWD);
 
 /**
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import path from 'path';
 import { toJS, resolve, versionCheck } from './util';
 import { Document } from './document';
 import { parse } from './parser';
@@ -90,9 +91,9 @@ export default async function bundle(
   }
 
   if (options.baseDir && typeof options.baseDir === 'string') {
-    process.chdir(options.baseDir);
+    process.chdir(path.resolve(originDir, options.baseDir));
   } else if (options.baseDir && Array.isArray(options.baseDir)) {
-    process.chdir(String(options.baseDir[0])); // guard against passing an array
+    process.chdir(path.resolve(originDir, String(options.baseDir[0]))); // guard against passing an array
   }
 
   const readFiles = files.map(file => readFileSync(file, 'utf-8')); // eslint-disable-line

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,6 @@ import { parse } from './parser';
 
 import type { AsyncAPIObject } from './spec-types';
 
-// remember the directory where execution of the program started
-export const originDir = String(process.env.PWD);
-
 /**
  *
  * @param {string | string[]} files One or more relative/absolute paths to
@@ -84,6 +81,9 @@ export default async function bundle(
   files: string[] | string,
   options: any = {}
 ) {
+  // remember the directory where execution of the program started
+  const originDir = String(process.env.PWD);
+
   // if one string was passed, convert it to an array
   if (typeof files === 'string') {
     files = Array.from(files.split(' '));
@@ -119,7 +119,7 @@ export default async function bundle(
 
   // return to the starting directory before finishing the execution
   if (options.baseDir) {
-    process.chdir(originDir);    
+    process.chdir(originDir);
   }
 
   return new Document(resolvedJsons, options.base);

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,9 @@ export default async function bundle(
   );
 
   // return to the starting directory before finishing the execution
-  process.chdir(originDir);
+  if (options.baseDir) {
+    process.chdir(originDir);    
+  }
 
   return new Document(resolvedJsons, options.base);
 }


### PR DESCRIPTION
This PR introduces an explicit return to the directory in which the program began execution to make its behavior more predictable, and improves the resolution of the path specified in `baseDir`.

Fixes https://github.com/asyncapi/bundler/issues/166