### PR TITLE
chore: update test AsyncAPI Documents to v3

### DIFF
--- a/tests/all.yml
+++ b/tests/all.yml
@@ -1,22 +1,39 @@
-asyncapi: 2.0.0
-id: urn:zbos-mqtt-api
-defaultContentType: application/json
+asyncapi: 3.0.0
+id: 'urn:zbos-mqtt-api'
 info:
   title: ZBOS MQTT API
   version: 2.6.3
   description: API for communication with ZBOS by Zora Robotics.
   contact:
     email: info@zorarobotics.be
+defaultContentType: application/json
+servers:
+  local:
+    host: 127.0.0.1
+    protocol: mqtt
+    description: This is the local robot broker.
+    variables:
+      port:
+        enum:
+          - '1883'
+          - '9001'
+        default: '1883'
+  cloud:
+    host: zbos-mqtt.zoracloud.com
+    protocol: mqtt
+    description: This is the cloud broker.
+    variables:
+      port:
+        enum:
+          - '1883'
+          - '1884'
+          - '9001'
+          - '9002'
 channels:
   zbos/audio/player/start:
-    publish:
-      summary: Play media
-      description: |
-        Play specific media from audio options
-      tags:
-        - name: Audio
-          description: All audio related topics.
-      message:
+    address: zbos/audio/player/start
+    messages:
+      publish.message:
         payload:
           type: object
           properties:
@@ -29,38 +46,72 @@ channels:
         name: AudioOptions
         examples:
           - payload:
-              requestId: "1"
+              requestId: '1'
               url: Url
               loop: true
   zbos/audio/player/stop:
-    publish:
-      summary: Stop media
-      description: ""
-      tags:
-        - name: Audio
-          description: All audio related topics.
-      message:
-        $ref: "#/components/messages/emptyMessage"
+    address: zbos/audio/player/stop
+    messages:
+      publish.message:
+        $ref: '#/components/messages/emptyMessage'
   zbos/camera/picture/event:
-    subscribe:
-      summary: "event: Get picture"
-      description: ""
-      tags:
-        - name: Camera
-          description: All camera related topics.
-      message:
+    address: zbos/camera/picture/event
+    messages:
+      subscribe.message:
         payload:
           type: string
         name: String
   zbos/camera/picture/get:
-    publish:
-      summary: Get picture
-      description: ""
-      tags:
-        - name: Camera
-          description: All camera related topics.
-      message:
-        $ref: "#/components/messages/keyMessage"
+    address: zbos/camera/picture/get
+    messages:
+      publish.message:
+        $ref: '#/components/messages/keyMessage'
+operations:
+  zbos/audio/player/start.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/zbos~1audio~1player~1start'
+    summary: Play media
+    description: |
+      Play specific media from audio options
+    tags:
+      - name: Audio
+        description: All audio related topics.
+    messages:
+      - $ref: '#/channels/zbos~1audio~1player~1start/messages/publish.message'
+  zbos/audio/player/stop.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/zbos~1audio~1player~1stop'
+    summary: Stop media
+    description: ''
+    tags:
+      - name: Audio
+        description: All audio related topics.
+    messages:
+      - $ref: '#/channels/zbos~1audio~1player~1stop/messages/publish.message'
+  zbos/camera/picture/event.subscribe:
+    action: send
+    channel:
+      $ref: '#/channels/zbos~1camera~1picture~1event'
+    summary: 'event: Get picture'
+    description: ''
+    tags:
+      - name: Camera
+        description: All camera related topics.
+    messages:
+      - $ref: '#/channels/zbos~1camera~1picture~1event/messages/subscribe.message'
+  zbos/camera/picture/get.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/zbos~1camera~1picture~1get'
+    summary: Get picture
+    description: ''
+    tags:
+      - name: Camera
+        description: All camera related topics.
+    messages:
+      - $ref: '#/channels/zbos~1camera~1picture~1get/messages/publish.message'
 components:
   messages:
     emptyMessage:
@@ -80,25 +131,4 @@ components:
       examples:
         - payload:
             key: ABCxyz
-servers:
-  local:
-    url: 127.0.0.1
-    protocol: mqtt
-    description: This is the local robot broker.
-    variables:
-      port:
-        enum:
-          - "1883"
-          - "9001"
-        default: "1883"
-  cloud:
-    url: zbos-mqtt.zoracloud.com
-    protocol: mqtt
-    description: This is the cloud broker.
-    variables:
-      port:
-        enum:
-          - "1883"
-          - "1884"
-          - "9001"
-          - "9002"
+

--- a/tests/asyncapi.yaml
+++ b/tests/asyncapi.yaml
@@ -1,10 +1,19 @@
-asyncapi: '2.2.0'
+asyncapi: 3.0.0
 info:
   title: Account Service
   version: 1.0.0
   description: This service is in charge of processing user signups
 channels:
   user/signedup:
-    subscribe:
-      message:
-        $ref: 'tests/messages.yaml#/messages/UserSignedUp'
+    address: user/signedup
+    messages:
+      subscribe.message:
+        $ref: tests/messages.yaml#/messages/UserSignedUp
+operations:
+  user/signedup.subscribe:
+    action: send
+    channel:
+      $ref: '#/channels/user~1signedup'
+    messages:
+      - $ref: tests/messages.yaml#/messages/UserSignedUp
+

--- a/tests/audio.yml
+++ b/tests/audio.yml
@@ -1,22 +1,17 @@
-asyncapi: 2.0.0
+asyncapi: 3.0.0
 id: 'urn:zbos-mqtt-api'
-defaultContentType: application/json
 info:
   title: Audio
   version: 2.6.3
   description: API for communication with ZBOS by Zora Robotics.
   contact:
     email: info@zorarobotics.be
+defaultContentType: application/json
 channels:
   zbos/audio/player/start:
-    publish:
-      summary: Play media
-      description: |
-        Play specific media from audio options
-      tags:
-        - name: Audio
-          description: All audio related topics.
-      message:
+    address: zbos/audio/player/start
+    messages:
+      publish.message:
         payload:
           type: object
           properties:
@@ -33,14 +28,34 @@ channels:
               url: Url
               loop: true
   zbos/audio/player/stop:
-    publish:
-      summary: Stop media
-      description: ''
-      tags:
-        - name: Audio
-          description: All audio related topics.
-      message:
+    address: zbos/audio/player/stop
+    messages:
+      publish.message:
         $ref: '#/components/messages/emptyMessage'
+operations:
+  zbos/audio/player/start.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/zbos~1audio~1player~1start'
+    summary: Play media
+    description: |
+      Play specific media from audio options
+    tags:
+      - name: Audio
+        description: All audio related topics.
+    messages:
+      - $ref: '#/channels/zbos~1audio~1player~1start/messages/publish.message'
+  zbos/audio/player/stop.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/zbos~1audio~1player~1stop'
+    summary: Stop media
+    description: ''
+    tags:
+      - name: Audio
+        description: All audio related topics.
+    messages:
+      - $ref: '#/channels/zbos~1audio~1player~1stop/messages/publish.message'
 components:
   messages:
     emptyMessage:
@@ -48,3 +63,4 @@ components:
         type: object
       name: EmptyMessage
       summary: Empty message
+

--- a/tests/base.yml
+++ b/tests/base.yml
@@ -1,15 +1,15 @@
-asyncapi: 2.0.0
+asyncapi: 3.0.0
 id: 'urn:zbos-mqtt-api'
-defaultContentType: 'application/json'
 info:
   title: ZBOS MQTT API
   version: 2.6.3
   description: API for communication with ZBOS by Zora Robotics.
   contact:
     email: info@zorarobotics.be
+defaultContentType: application/json
 servers:
   local:
-    url: '127.0.0.1'
+    host: 127.0.0.1
     protocol: mqtt
     description: This is the local robot broker.
     variables:
@@ -19,7 +19,7 @@ servers:
           - '9001'
         default: '1883'
   cloud:
-    url: zbos-mqtt.zoracloud.com
+    host: zbos-mqtt.zoracloud.com
     protocol: mqtt
     description: This is the cloud broker.
     variables:
@@ -29,3 +29,4 @@ servers:
           - '1884'
           - '9001'
           - '9002'
+

--- a/tests/camera.yml
+++ b/tests/camera.yml
@@ -1,33 +1,48 @@
-asyncapi: 2.0.0
+asyncapi: 3.0.0
 id: 'urn:zbos-mqtt-api'
-defaultContentType: application/json
 info:
   title: Camera
   version: 2.6.3
   description: API for communication with ZBOS by Zora Robotics.
   contact:
     email: info@zorarobotics.be
+defaultContentType: application/json
 channels:
   zbos/camera/picture/event:
-    subscribe:
-      summary: 'event: Get picture'
-      description: ''
-      tags:
-        - name: Camera
-          description: All camera related topics.
-      message:
+    address: zbos/camera/picture/event
+    messages:
+      subscribe.message:
         payload:
           type: string
         name: String
   zbos/camera/picture/get:
-    publish:
-      summary: Get picture
-      description: ''
-      tags:
-        - name: Camera
-          description: All camera related topics.
-      message:
+    address: zbos/camera/picture/get
+    messages:
+      publish.message:
         $ref: '#/components/messages/keyMessage'
+operations:
+  zbos/camera/picture/event.subscribe:
+    action: send
+    channel:
+      $ref: '#/channels/zbos~1camera~1picture~1event'
+    summary: 'event: Get picture'
+    description: ''
+    tags:
+      - name: Camera
+        description: All camera related topics.
+    messages:
+      - $ref: '#/channels/zbos~1camera~1picture~1event/messages/subscribe.message'
+  zbos/camera/picture/get.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/zbos~1camera~1picture~1get'
+    summary: Get picture
+    description: ''
+    tags:
+      - name: Camera
+        description: All camera related topics.
+    messages:
+      - $ref: '#/channels/zbos~1camera~1picture~1get/messages/publish.message'
 components:
   messages:
     keyMessage:
@@ -42,3 +57,4 @@ components:
       examples:
         - payload:
             key: ABCxyz
+

--- a/tests/check.yml
+++ b/tests/check.yml
@@ -1,12 +1,13 @@
-asyncapi: 2.2.0
+asyncapi: 3.0.0
 info:
   title: Account Service
   version: 1.0.0
   description: This service is in charge of processing user signups
 channels:
   user/signedup:
-    subscribe:
-      message:
+    address: user/signedup
+    messages:
+      subscribe.message:
         payload:
           type: object
           properties:
@@ -17,3 +18,11 @@ channels:
               type: string
               format: email
               description: Email of the user
+operations:
+  user/signedup.subscribe:
+    action: send
+    channel:
+      $ref: '#/channels/user~1signedup'
+    messages:
+      - $ref: '#/channels/user~1signedup/messages/subscribe.message'
+


### PR DESCRIPTION
This PR updates the AsyncAPI Documents used for testing to version `3.0.0`.

The files were converted using `asyncapi convert`.
