### PR TITLE
fix: remove obsolete `try...catch`

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -54,12 +54,10 @@ export const resolve = async (
 ) => {
   const docs = [];
 
-  try {
-    for (const asyncapiDocument of asyncapiDocuments) {
-      await parse(asyncapiDocument, specVersion, options);
-      docs.push(asyncapiDocument);
-    }
-  } catch (e) {} // eslint-disable-line
+  for (const asyncapiDocument of asyncapiDocuments) {
+    await parse(asyncapiDocument, specVersion, options);
+    docs.push(asyncapiDocument);
+  }
 
   return docs;
 };

--- a/tests/wrong-external-ref.yaml
+++ b/tests/wrong-external-ref.yaml
@@ -1,0 +1,10 @@
+asyncapi: '2.2.0'
+info:
+  title: Account Service
+  version: 1.0.0
+  description: This service is in charge of processing user signups
+channels:
+  user/signedup:
+    subscribe:
+      message:
+          $ref: "./audio.yml#/components/messages/WrongReference"


### PR DESCRIPTION
**Description**

Issue https://github.com/asyncapi/cli/issues/1475 gives an example where an invalid external reference is ignored, and all other documents are skipped. Instead of silently failing, this PR proposes to let the error propagate.

**Related issue(s)**
Fixes https://github.com/asyncapi/cli/issues/1475