### PR TITLE
feat!: resolve $refs relative to document

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -23,12 +23,12 @@ export class Document {
    * @param {Object[]} parsedJSONList
    * @param {Object} base
    */
-  constructor(parsedJSONList: AsyncAPIObject[], base: AsyncAPIObject) {
+  constructor(parsedJSONList: AsyncAPIObject[], base?: AsyncAPIObject) {
     for (const resolvedJSON of parsedJSONList) {
       this._doc = merge(this._doc, resolvedJSON);
     }
 
-    if (typeof base !== 'undefined') {
+    if (base) {
       this._doc = merge(this._doc, base);
     }
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,6 +4,8 @@ import { Parser } from '@asyncapi/parser';
 import type { ParserOptions as $RefParserOptions } from '@apidevtools/json-schema-ref-parser';
 import type { AsyncAPIObject } from 'spec-types';
 
+import path from 'path';
+
 const parser = new Parser();
 
 let RefParserOptions: $RefParserOptions;
@@ -12,12 +14,14 @@ let RefParserOptions: $RefParserOptions;
  * Function fully dereferences the provided AsyncAPI Document.
  * @param {Object[]} JSONSchema
  * @param {number} specVersion
+ * @param {string} filePath
  * @param {Object} options
  * @private
  */
 export async function parse(
   JSONSchema: AsyncAPIObject,
   specVersion: number,
+  filePath: string,
   options: any = {}
 ) {
   let validationResult: any[] = [];
@@ -74,6 +78,12 @@ export async function parse(
       );
   }
 
+  let previousDir: string | null = null;
+  if (!options.baseDir) {
+    previousDir = process.cwd();
+    process.chdir(path.dirname(filePath));
+  }
+
   const dereferencedJSONSchema = await $RefParser.dereference(
     JSONSchema,
     RefParserOptions
@@ -102,6 +112,10 @@ export async function parse(
       validationResult.filter(element => element.severity === 0)
     );
     throw new Error();
+  }
+
+  if (previousDir) {
+    process.chdir(previousDir);
   }
 
   return dereferencedJSONSchema;

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,11 @@ import { ParserError } from './errors';
 
 import type { AsyncAPIObject } from './spec-types';
 
+export interface AsyncAPIDocumentFromFileSystem {
+  asyncapi: AsyncAPIObject;
+  path: string;
+}
+
 /**
  * @private
  */
@@ -48,15 +53,15 @@ export const toJS = (asyncapiYAMLorJSON: string | object) => {
  * @private
  */
 export const resolve = async (
-  asyncapiDocuments: AsyncAPIObject[],
+  asyncapiDocuments: AsyncAPIDocumentFromFileSystem[],
   specVersion: number,
   options: any
 ) => {
   const docs = [];
 
   for (const asyncapiDocument of asyncapiDocuments) {
-    await parse(asyncapiDocument, specVersion, options);
-    docs.push(asyncapiDocument);
+    await parse(asyncapiDocument.asyncapi, specVersion, asyncapiDocument.path, options);
+    docs.push(asyncapiDocument.asyncapi);
   }
 
   return docs;

--- a/tests/base-option/camera.yaml
+++ b/tests/base-option/camera.yaml
@@ -7,4 +7,4 @@ channels:
   camera/click:
     subcribe:
       message:
-        $ref: './tests/base-option/messages.yaml#/messages/clickPhoto'
+        $ref: './messages.yaml#/messages/clickPhoto'

--- a/tests/base-option/lights.yaml
+++ b/tests/base-option/lights.yaml
@@ -7,4 +7,4 @@ channels:
   lights/On:
     subcribe:
       message:
-        $ref: './tests/base-option/messages.yaml#/messages/LightsOn'
+        $ref: './messages.yaml#/messages/LightsOn'


### PR DESCRIPTION
**Description**

This implements the behaviour describes in #178 as a proposal for an implementation, in case the related change is accepted.

This does change the default behaviour to resolve $refs relative to the document which is what the CLI would do as well.
For details look into the linked issue.

Alternatively it would also be possible to do this in a non-breaking way by only applying the changed behaviour when an option like `--path-relative-to-document` is specified, if that would be prefered.

**Related issue(s)**
Resolves #178 