### PR TITLE
chore: use typescript type for declaring options

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -23,12 +23,12 @@ export class Document {
    * @param {Object[]} parsedJSONList
    * @param {Object} base
    */
-  constructor(parsedJSONList: AsyncAPIObject[], base: AsyncAPIObject) {
+  constructor(parsedJSONList: AsyncAPIObject[], base?: AsyncAPIObject) {
     for (const resolvedJSON of parsedJSONList) {
       this._doc = merge(this._doc, resolvedJSON);
     }
 
-    if (typeof base !== 'undefined') {
+    if (base) {
       this._doc = merge(this._doc, base);
     }
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,6 +3,7 @@ import { Parser } from '@asyncapi/parser';
 
 import type { ParserOptions as $RefParserOptions } from '@apidevtools/json-schema-ref-parser';
 import type { AsyncAPIObject } from 'spec-types';
+import type { BundlerOptions } from 'index';
 
 const parser = new Parser();
 
@@ -18,7 +19,7 @@ let RefParserOptions: $RefParserOptions;
 export async function parse(
   JSONSchema: AsyncAPIObject,
   specVersion: number,
-  options: any = {}
+  options: BundlerOptions = {}
 ) {
   let validationResult: any[] = [];
 
@@ -82,6 +83,7 @@ export async function parse(
   // Option `noValidation: true` is used by the testing system, which
   // intentionally feeds Bundler wrong AsyncAPI Documents, thus it is not
   // documented.
+  // @ts-ignore
   if (!options.noValidation) {
     validationResult = await parser.validate(
       JSON.parse(JSON.stringify(dereferencedJSONSchema))

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,7 @@ import { parse } from './parser';
 import { ParserError } from './errors';
 
 import type { AsyncAPIObject } from './spec-types';
+import type { BundlerOptions } from './index';
 
 /**
  * @private
@@ -39,20 +40,12 @@ export const toJS = (asyncapiYAMLorJSON: string | object) => {
   return yaml.load(asyncapiYAMLorJSON);
 };
 
-/**
- *
- * @param {Object} asyncapiDocuments
- * @param {Object} options
- * @param {boolean} options.xOrigin
- * @returns {Array<Object>}
- * @private
- */
-export const resolve = async (
+export async function resolve(
   asyncapiDocuments: AsyncAPIObject[],
   specVersion: number,
-  options: any
-) => {
-  const docs = [];
+  options: BundlerOptions
+) {
+  const docs: AsyncAPIObject[] = [];
 
   for (const asyncapiDocument of asyncapiDocuments) {
     await parse(asyncapiDocument, specVersion, options);
@@ -60,7 +53,7 @@ export const resolve = async (
   }
 
   return docs;
-};
+}
 
 /**
  *


### PR DESCRIPTION
Currently the options object of the bundler is just declared as `any`, despite using typescript.

Adding a type for it improves autocompletion when trying to use the bundler as a library in another project and generally improves type recognition in the code.