### PR TITLE
fix: replace native `structuredClone()` with a polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@apidevtools/json-schema-ref-parser": "^11.5.4",
         "@asyncapi/parser": "^3.1.0",
         "@types/json-schema": "^7.0.11",
+        "@ungap/structured-clone": "^1.2.0",
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^6.0.1",
         "lodash": "^4.17.21"
@@ -27,6 +28,7 @@
         "@types/js-yaml": "^4.0.5",
         "@types/lodash": "^4.14.186",
         "@types/node": "^18.8.2",
+        "@types/ungap__structured-clone": "^1.2.0",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
         "eslint": "^8.24.0",
@@ -3565,6 +3567,12 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
+    "node_modules/@types/ungap__structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
+      "integrity": "sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==",
+      "dev": true
+    },
     "node_modules/@types/urijs": {
       "version": "1.19.25",
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.25.tgz",
@@ -3875,8 +3883,7 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.5.4",
     "@asyncapi/parser": "^3.1.0",
     "@types/json-schema": "^7.0.11",
+    "@ungap/structured-clone": "^1.2.0",
     "js-yaml": "^4.1.0",
     "jsonpath-plus": "^6.0.1",
     "lodash": "^4.17.21"
@@ -56,6 +57,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.186",
     "@types/node": "^18.8.2",
+    "@types/ungap__structured-clone": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "eslint": "^8.24.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import { merge } from 'lodash';
+import structuredClone from '@ungap/structured-clone';
 import { parse } from './parser';
 import { ParserError } from './errors';
 


### PR DESCRIPTION
This PR replaces native `structuredClone()` with a polyfill to keep compatibility with Node.js v16.