### PR TITLE
fix: add v2-specific root properties to sorting alg

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -140,7 +140,7 @@ export async function mergeIntoBaseFile(
 }
 
 // Purely decorative stuff, just to bring the order of the AsyncAPI Document's
-// properties into a familiar form.
+// root properties into a familiar form.
 export function orderPropsAccToAsyncAPISpec(
   inputAsyncAPIObject: any
 ): AsyncAPIObject {
@@ -148,6 +148,8 @@ export function orderPropsAccToAsyncAPISpec(
     'asyncapi',
     'id',
     'info',
+    'tags', // v2-specific root property
+    'externalDocs', // v2-specific root property
     'defaultContentType',
     'servers',
     'channels',
@@ -156,7 +158,21 @@ export function orderPropsAccToAsyncAPISpec(
   ];
 
   const outputAsyncAPIObject: any = {};
+  let i = 0;
 
+  // Making the best guess where root properties that are not specified in the
+  // AsyncAPI Specification were located in the original AsyncAPI Document
+  // (inserting them between known root properties.)
+  // DISCLAIMER: The original order is not guaranteed, it is only an
+  // extrapolating guess.
+  for (const key of Object.keys(inputAsyncAPIObject)) {
+    if (!orderOfPropsAccToAsyncAPISpec.includes(key)) {
+      orderOfPropsAccToAsyncAPISpec.splice(i, 0, key);
+    }
+    i++;
+  }
+
+  // Merging of known AsyncAPI Object root properties in a familiar order.
   for (const prop of orderOfPropsAccToAsyncAPISpec) {
     if (inputAsyncAPIObject[`${prop}`]) {
       outputAsyncAPIObject[`${prop}`] = structuredClone(

--- a/tests/gh-185.yaml
+++ b/tests/gh-185.yaml
@@ -1,0 +1,48 @@
+asyncapi: '2.0.0'
+x-company-attr-1: attr-value-1
+x-company-attr-2: attr-value-2
+id: 'urn:rpc:example:server'
+defaultContentType: application/json
+
+info:
+  title: RPC Server Example
+  description: This example demonstrates how to define an RPC server.
+  version: '1.0.0'
+  x-company-version: 1.2.3
+
+tags:
+  - name: my-tag
+    description: tag description
+
+channels:
+  '{queue}':
+    parameters:
+      queue:
+        schema:
+          type: string
+          pattern: '^amq\\.gen\\-.+$'
+    bindings:
+      amqp:
+        is: queue
+        queue:
+          exclusive: true
+    subscribe:
+      operationId: sendSumResult
+      bindings:
+        amqp:
+          ack: true
+      message:
+        correlationId:
+          location: $message.header#/correlation_id
+        payload:
+          type: object
+          properties:
+            result:
+              type: number
+              examples:
+                - 7
+
+servers:
+  production:
+    url: rabbitmq.example.org
+    protocol: amqp


### PR DESCRIPTION
This PR:

- Adds v2-specific root properties to the algorithm of sorting the resulting bundled AsyncAPI Document's root properties (to bring them into a familiar form.)

- Extrapolates the location of `x-` properties in the original AsyncAPI Document, attempting to make as little visual change to the resulting bundled AsyncAPI Document as possible.

Related to https://github.com/asyncapi/bundler/issues/185