### PR TITLE
fix: update @apidevtools/json-schema-ref-parser to v15.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^14.2.1",
+        "@apidevtools/json-schema-ref-parser": "^15.3.6",
         "@types/json-schema": "^7.0.11",
         "@ungap/structured-clone": "^1.2.0",
         "js-yaml": "^4.1.0",
@@ -47,18 +47,15 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.1.tgz",
-      "integrity": "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==",
+      "version": "15.3.6",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.3.6.tgz",
+      "integrity": "sha512-oPFDSviRrreUmCZn09LCD4S9QQa6j7zfEwBM1pkGa/kXY0O4sXsEXn4emLP/Tt6tik2+BtgwKk2eldAeOWZ2Rw==",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.2.0"
       },
       "engines": {
-        "node": ">= 20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@types/json-schema": "^7.0.15"
@@ -11423,9 +11420,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "/lib"
   ],
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^14.2.1",
+    "@apidevtools/json-schema-ref-parser": "^15.3.6",
     "@types/json-schema": "^7.0.11",
     "@ungap/structured-clone": "^1.2.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
This PR updates the NPM package `@apidevtools/json-schema-ref-parser` to `15.3.6`.

NB: Starting with `Bundler` version `1.0.1`, the minimum required Node.js version is `24`.